### PR TITLE
Added '$' to variable names in log messages to indicate them as variables

### DIFF
--- a/conf/conf-example-strict.ini
+++ b/conf/conf-example-strict.ini
@@ -72,14 +72,14 @@ OffSet = 3
 #---------------------------------------------
 # Custom Ban / Kick Messages
 #	Keywords
-# 		PLAYER_NAME = Player Name
-# 		SERVER_NAME = Server Name
-# 		LOG_FILE = Log File
-# 		DATE_TIME = Date + Time
+# 		$PLAYER_NAME = Player Name
+# 		$SERVER_NAME = Server Name
+# 		$LOG_FILE = Log File
+# 		$DATE_TIME = Date + Time
 
-Ban Message = DATE_TIME: PLAYER_NAME on SERVER_NAME
-Kick Message = DATE_TIME: PLAYER_NAME on SERVER_NAME
-Report Message = Player Name: PLAYER_NAME, Server: SERVER_NAME, Date: DATE_TIME:, Logfile: LOG_FILE
+Ban Message = $DATE_TIME: $PLAYER_NAME on $SERVER_NAME
+Kick Message = $DATE_TIME: $PLAYER_NAME on $SERVER_NAME
+Report Message = Player Name: $PLAYER_NAME, Server: $SERVER_NAME, Date: $DATE_TIME:, Logfile: $LOG_FILE
 
 
 [Server 1]

--- a/conf/conf-example.ini
+++ b/conf/conf-example.ini
@@ -73,14 +73,14 @@ OffSet = 3
 #---------------------------------------------
 # Custom Ban / Kick Messages
 #	Keywords
-# 		PLAYER_NAME = Player Name
-# 		SERVER_NAME = Server Name
-# 		LOG_FILE = Log File
-# 		DATE_TIME = Date + Time
+# 		$PLAYER_NAME = Player Name
+# 		$SERVER_NAME = Server Name
+# 		$LOG_FILE = Log File
+# 		$DATE_TIME = Date + Time
 
-Ban Message = DATE_TIME: PLAYER_NAME on SERVER_NAME
-Kick Message = DATE_TIME: PLAYER_NAME on SERVER_NAME
-Report Message = Player Name: PLAYER_NAME, Server: SERVER_NAME, Date: DATE_TIME:, Logfile: LOG_FILE
+Ban Message = $DATE_TIME: $PLAYER_NAME on $SERVER_NAME
+Kick Message = $DATE_TIME: $PLAYER_NAME on $SERVER_NAME
+Report Message = Player Name: $PLAYER_NAME, Server: $SERVER_NAME, Date: $DATE_TIME:, Logfile: $LOG_FILE
 
 
 [Server 1]

--- a/modules/bans.py
+++ b/modules/bans.py
@@ -146,12 +146,12 @@ class Bans:
 			self.saveBanInfo()
 			
 	def formatMessage(self, template, player_name, server_name, log_file, date_time, guid, ip):
-		tmp = template.replace("LOG_FILE", log_file)
-		tmp = tmp.replace("DATE_TIME", date_time)
-		tmp = tmp.replace("SERVER_NAME", server_name)
-		tmp = tmp.replace("PLAYER_NAME", player_name)
-		tmp = tmp.replace("GUID", guid)
-		tmp = tmp.replace("IP", ip)
+		tmp = template.replace("$LOG_FILE", log_file)
+		tmp = tmp.replace("$DATE_TIME", date_time)
+		tmp = tmp.replace("$SERVER_NAME", server_name)
+		tmp = tmp.replace("$PLAYER_NAME", player_name)
+		tmp = tmp.replace("$GUID", guid)
+		tmp = tmp.replace("$IP", ip)
 		return tmp
 
 	def addBan(self, unique_id, info, logname, ban_template, report_template, time): #{ID,Reason}

--- a/modules/logs_battleye.py
+++ b/modules/logs_battleye.py
@@ -170,10 +170,10 @@ class Scanner:
 				sys.exit()
 
 	def kick_ban_msg(self, template, player_name, server_name, log_file, date_time):
-		tmp = string.replace(template, "PLAYER_NAME", player_name)
-		tmp = string.replace(tmp, "SERVER_NAME", server_name)
-		tmp = string.replace(tmp, "LOG_FILE", log_file)
-		tmp = string.replace(tmp, "DATE_TIME", date_time)
+		tmp = string.replace(template, "$PLAYER_NAME", player_name)
+		tmp = string.replace(tmp, "$SERVER_NAME", server_name)
+		tmp = string.replace(tmp, "$LOG_FILE", log_file)
+		tmp = string.replace(tmp, "$DATE_TIME", date_time)
 		return tmp
 
 	def update_bans(self, logname, data, time="-1", update=False):


### PR DESCRIPTION
I had the two characters 'IP' in my ban message. This caused the script to replace them by the IP of the player, what is obviously not what I wanted. Therefore I just added the character '$' in front of the variable names to clearly indicate them as variables.
